### PR TITLE
chore: ignore Tailwind warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+!.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore"
+}


### PR DESCRIPTION
VS Code에서 @tailwind 경고가 계속 떠서 css.lint.unknownAtRules 값을 ignore로 설정해 경고를 잠궜습니다 .                                                                     
vscode 전체가 git에서 무시되던 상태라, 예외를 추가해 이 파일만 공유할 수 있게 해두었습니다.
