### PR TITLE
fix: chrome 식별자 타입 오류 해결

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,7 +28,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": ["node", "vite/client"]
+    "types": ["node", "vite/client", "chrome"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
types에 chrome을 추가하면 전역 chrome과 모든 API 타입이 로드되어 에러가 사라지고, 자동완성/타입체크가 가능해집니다.