### PR TITLE
chore: add prettier check pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "vite": "^7.1.7"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,json,css,scss,md}": "prettier --write"
+    "*.{ts,tsx,js,jsx,json,css,scss,md}": "prettier --check"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prepare": "husky"
   },
   "dependencies": {
     "lucide-react": "^0.544.0",
@@ -32,6 +33,8 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.6",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.7.1",
@@ -39,5 +42,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json,css,scss,md}": "prettier --write"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 ﻿// src/App.tsx
-import { Navigate, Route, Routes } from "react-router-dom";
-import Sidebar from "./components/sidebar";
-import Dashboard from "./pages/Dashboard/Dashboard";
-import Impr from "./pages/Impr";
-import Popup from "./pages/Popup";
+import { Navigate, Route, Routes } from 'react-router-dom'
+import Sidebar from './components/sidebar'
+import Dashboard from './pages/Dashboard/Dashboard'
+import Impr from './pages/Impr'
+import Popup from './pages/Popup'
 
 export default function App() {
   return (
@@ -19,5 +19,5 @@ export default function App() {
 
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
-  );
+  )
 }


### PR DESCRIPTION
 pre-commit 훅에서 npx lint-staged 실행하도록 설정.                                        
 스테이징된 파일에 prettier --check를 적용해 포맷 불일치 시 커밋을 막음.                   
 ESLint는 실행하지 않음. 오직 Prettier 포맷 확인만 수행.  

<img width="641" height="393" alt="image (1)" src="https://github.com/user-attachments/assets/ba7124b3-bc6c-4cbd-8485-5cda02ca074d" />
