### PR TITLE
build: .env 주입 및 host_permission 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env*

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -1,11 +1,16 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 
-export default defineManifest(() => ({
-  manifest_version: 3,
-  name: 'Chrome Extension Performance Test',
-  version: '1.0.0',
-  action: {
-    default_popup: 'index.html#/popup',
-  },
-  permissions: ['tabs'],
-}))
+export default defineManifest(() => {
+  const hp = process.env.VITE_HOST_PERMISSIONS!
+
+  return {
+    manifest_version: 3,
+    name: 'Chrome Extension Performance Test',
+    version: '1.0.0',
+    action: {
+      default_popup: 'index.html#/popup',
+    },
+    permissions: ['tabs'],
+    host_permissions: [hp],
+  }
+})

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -1,7 +1,10 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 
 export default defineManifest(() => {
-  const hp = process.env.VITE_HOST_PERMISSIONS!
+  const hostPermission = process.env.VITE_HOST_PERMISSIONS
+  if (!hostPermission) {
+    throw new Error('VITE_HOST_PERMISSIONS is required.')
+  }
 
   return {
     manifest_version: 3,
@@ -11,6 +14,6 @@ export default defineManifest(() => {
       default_popup: 'index.html#/popup',
     },
     permissions: ['tabs'],
-    host_permissions: [hp],
+    host_permissions: [hostPermission],
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  // manifest.config.ts에서 환경 변수를 사용하기 위해 process.env에 주입
   Object.assign(process.env, env)
 
   return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,24 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { crx } from '@crxjs/vite-plugin'
 import manifest from './manifest.config'
 import { fileURLToPath, URL } from 'node:url'
 
-export default defineConfig({
-  plugins: [react(), crx({ manifest })],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  Object.assign(process.env, env)
+
+  return {
+    plugins: [react(), crx({ manifest })],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
     },
-  },
-  server: {
-    cors: {
-      origin: [/chrome-extension:\/\//],
+    server: {
+      cors: {
+        origin: [/chrome-extension:\/\//],
+      },
     },
-  },
+  }
 })


### PR DESCRIPTION
Vite 빌드 과정에서 loadEnv로 .env 값을 읽어 process.env에 병합하고, manifest.config.ts의 콜백 내부에서 process.env.VITE_HOST_PERMISSIONS 단일 값을 읽어 host_permissions: [값]으로 설정했습니다.

<img width="1026" height="785" alt="image" src="https://github.com/user-attachments/assets/f5758045-8f6f-4b85-ab84-15c194a4ff40" />
