### PR TITLE
feat : 기대효과 & 개선방안 페이지 API 연동   

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 
 .env*
+
+
+AGENTS.md

--- a/src/apis/solutionApis.ts
+++ b/src/apis/solutionApis.ts
@@ -1,0 +1,14 @@
+// import defaultAxios from './defaultAxios'
+
+// TODO 기대효과? API 받아오는거 다시 해야함
+// * 보안 지표
+// export const fetchSolutions = async (testId: string): <> => {
+//   try {
+//     const url = `/api/tests/${testId}/ai/recommendations`
+//     const response = await defaultAxios.get(url)
+//     return response.data
+//   } catch (error) {
+//     console.error('Failed to fetch cell sum data', error)
+//     throw error
+//   }
+// }

--- a/src/apis/solutionApis.ts
+++ b/src/apis/solutionApis.ts
@@ -1,14 +1,21 @@
 // import defaultAxios from './defaultAxios'
+import type { SolutionResponse } from '@/types/Solution.types'
+import defaultAxios from './defaultAxios'
 
 // TODO 기대효과? API 받아오는거 다시 해야함
-// * 보안 지표
-// export const fetchSolutions = async (testId: string): <> => {
-//   try {
-//     const url = `/api/tests/${testId}/ai/recommendations`
-//     const response = await defaultAxios.get(url)
-//     return response.data
-//   } catch (error) {
-//     console.error('Failed to fetch cell sum data', error)
-//     throw error
-//   }
-// }
+// * 개선방안 & 효과 API 패칭
+/**
+ * 개선방안 & 효과 API 패칭
+ * @param testId
+ * @returns
+ */
+export const fetchSolutions = async (testId: string): Promise<SolutionResponse> => {
+  try {
+    const url = `/api/tests/${testId}/ai/recommendations`
+    const response = await defaultAxios.get(url)
+    return response.data
+  } catch (error) {
+    console.error('Failed to fetch Solutions data', error)
+    throw error
+  }
+}

--- a/src/pages/Dashboard/CustomBarChart.tsx
+++ b/src/pages/Dashboard/CustomBarChart.tsx
@@ -48,12 +48,12 @@ import type { ChartProps } from '../../types/Chart.types.ts'
 // * 커스텀 바 차트
 
 // 예시 데이터
-const data = [
-  { name: 'LCP', value: 35 },
-  { name: 'CLS', value: 50 },
-  { name: 'INP', value: 70 },
-  { name: 'TBT', value: 40 },
-]
+// const data = [
+//   { name: 'LCP', value: 35 },
+//   { name: 'CLS', value: 50 },
+//   { name: 'INP', value: 70 },
+//   { name: 'TBT', value: 40 },
+// ]
 
 // 🎨 막대 끝 원 + 숫자 커스텀 shape
 const CustomBar = (props: any) => {

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ import type { AiPriority, DomainURL, ScoreTotal, Vital } from '@/types/Dashboard
 
 export default function PerformanceDashboardMain() {
   // TODO : 추후 테스트ID 동적으로  변경
-  const testId: string = '33a74007-2d72-4684-b882-67cc42b27f36'
+  const testId: string = '7b0c17e3-8af6-4834-9507-0abdcdb62690'
   // 변수 ====
   const [priorityData, setPriorityData] = useState<AiPriority[] | null>(null) // 우선 개선이 필요한 항목 데이터
   const [webVitalData, setWebVitalData] = useState<Vital[]>(performanceMetrics) // 우선 개선이 필요한 항목 데이터

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -4,8 +4,17 @@ import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 import lightningImg from '../../assets/icons/lightning.svg'
+import { useEffect, useState } from 'react'
+import { fetchSolutions } from '@/apis/solutionApis'
+import type { MajorImprovement, Solution, SolutionResponse } from '@/types/Solution.types'
+
+// Props 선언
+interface SolutionSliderProps {
+  data: MajorImprovement[] | null
+}
+
 // * 개선방안 슬라이더
-const SolutionSlider: React.FC = () => {
+const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
   const settings = {
     dots: true,
     infinite: true,
@@ -13,63 +22,68 @@ const SolutionSlider: React.FC = () => {
     slidesToShow: 3,
     slidesToScroll: 3,
   }
+
   return (
     <div className="slider-container mx-[1%] h-[230px] w-full">
       <Slider {...settings}>
-        {/* 
-        // TODO 추후 article 부분 소프트 코딩으로 변경 
-        
-        */}
-        <article className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md">
-          <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
-            <img src={lightningImg} alt="번개" />
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
-            <span className="text-[#3B82F6]">LCP</span> 0.8초 단축
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">
-            첫 화면 로딩이 빨라집니다.
-          </div>
-        </article>
-        <article className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md">
-          <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
-            <img src={lightningImg} alt="번개" />
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
-            <span className="text-[#3B82F6]">LCP</span> 0.8초 단축
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">
-            첫 화면 로딩이 빨라집니다.
-          </div>
-        </article>
-        <article className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md">
-          <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
-            <img src={lightningImg} alt="번개" />
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
-            <span className="text-[#3B82F6]">LCP</span> 0.8초 단축
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">
-            첫 화면 로딩이 빨라집니다.
-          </div>
-        </article>
-        <article className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md">
-          <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
-            <img src={lightningImg} alt="번개" />
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
-            <span className="text-[#3B82F6]">LCP</span> 0.8초 단축
-          </div>
-          <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">
-            첫 화면 로딩이 빨라집니다.
-          </div>
-        </article>
+        {data?.map((item) => (
+          <article
+            key={item.description}
+            className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md"
+          >
+            <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
+              <img src={lightningImg} alt="번개" />
+            </div>
+            <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
+              <span className="text-[#3B82F6]">{item.metric}</span> {item.title}
+            </div>
+            <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">{item.description}</div>
+          </article>
+        ))}
       </Slider>
     </div>
   )
 }
 
 export default function SolutionPage() {
+  const testId: string = '7b0c17e3-8af6-4834-9507-0abdcdb62690'
+
+  // ! 변수 ===
+  // 기존 점수
+  const [beforeScore, setBeforeScore] = useState<number>(0)
+  // 개선 예상 점수
+  const [afterScore, setAfterScore] = useState<number>(0)
+  // 개선 예상 점수 +
+  const [afterScoreDetail, setAfterScoreDetail] = useState<number>(0)
+
+  // 개선 방안 - web바이탈
+  const [solutionWebVitalData, setSolutionWebVitalData] = useState<Solution[] | null>(null)
+  // 개선방안 - 보안
+  const [solutionSecurityData, setSolutionSecurityData] = useState<Solution[] | null>(null)
+  // 기대 효과
+  const [majorImprovementData, setMajorImprovementData] = useState<MajorImprovement[] | null>(null)
+
+  // * 첫 렌더링 시 API 호출
+  useEffect(() => {
+    // * 우선 개선사항 받아오기
+    const getSolutions = async () => {
+      try {
+        const response: SolutionResponse = await fetchSolutions(testId) // 대시보드/우선개선이 필요한 항목
+        setBeforeScore(response.success.data.overallTotalBefore) // 기존 점수
+        setAfterScore(response.success.data.overallTotalAfter) // 개선 예상 점수
+        setAfterScoreDetail(response.success.data.overallExpectedImprovement) // 개선 예상 점수 디테일
+        setSolutionWebVitalData(response.success.data.webElements) // 웹바이탈 개선방안
+        setSolutionSecurityData(response.success.data.securityMetrics) // 보안 개선방안
+        // TODO : 이 위에 5개 소프트하게 만들기
+        setMajorImprovementData(response.success.data.majorImprovements) // 기대 효과
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    getSolutions()
+  }, [])
+
   return (
     // TODO : 차트 동적으로 되게, 더 동글동글하게 ui 바꿔야함
     <main className="flex w-full max-w-[1700px] flex-col gap-y-6 bg-[#F5F9FA] px-6 py-6 lg:px-8">
@@ -143,7 +157,7 @@ export default function SolutionPage() {
         {/* 개선 기대효과 */}
         <article className={styles.solution_container}>
           <h2 className={styles.title}>개선 기대효과</h2>
-          <SolutionSlider />
+          <SolutionSlider data={majorImprovementData} />
         </article>
       </section>
     </main>

--- a/src/types/Solution.types.ts
+++ b/src/types/Solution.types.ts
@@ -1,0 +1,44 @@
+// * 개선 방안 & 효과 전체
+
+// * 개선 방안 - 성능, 보안 (2개 형태 동일 )
+export interface Solution {
+  name: string // 제목
+  status: string
+  benefitSummary: string // 간단 설명
+  expectedScoreGain: number // 예산 개선 효과
+  relatedMetrics: string[] // 연관 지표 리스트 (CLS...)
+  benefitDetail: string // 상세 추가 설명
+}
+
+// * 개선방안 - 보안
+// export interface MajorImprovement {
+//   // 개선 방안 - 보안
+//   name: string
+//   status: string
+//   benefitSummary: string
+//   expectedScoreGain: number
+//   relatedMetrics: string[] // 연관 지표들 (CSL,,,..)
+//   benefitDetail: string //
+// }
+
+// *기대효과
+export interface MajorImprovement {
+  metric: string // 태그 지표 종륲
+  title: string // 제목
+  description: string // 설명
+}
+
+//* 전체 기대효과 & 개선방안 페이지
+export interface SolutionResponse {
+  success: {
+    message: string
+    overallExpectedImprovement: number // 개선 예상점수 오른부분
+    overallTotalAfter: number // 개선 예상 점수
+    overallTotalBefore: number // 기존 점수
+
+    webElements: Solution[] // 개선 방안 ( 웹바이탈)
+    securityMetrics: Solution[] // 개선 방안 (보안)
+
+    majorImprovements: MajorImprovement[] // 기대효과 리스트
+  }
+}

--- a/src/types/Solution.types.ts
+++ b/src/types/Solution.types.ts
@@ -31,14 +31,16 @@ export interface MajorImprovement {
 //* 전체 기대효과 & 개선방안 페이지
 export interface SolutionResponse {
   success: {
+    data: {
+      overallTotalBefore: number // 기존 점수
+      overallTotalAfter: number // 개선 예상 점수
+      overallExpectedImprovement: number // 개선 예상점수 오른부분
+
+      webElements: Solution[] // 개선 방안 ( 웹바이탈)
+      securityMetrics: Solution[] // 개선 방안 (보안)
+
+      majorImprovements: MajorImprovement[] // 기대효과 리스트
+    }
     message: string
-    overallExpectedImprovement: number // 개선 예상점수 오른부분
-    overallTotalAfter: number // 개선 예상 점수
-    overallTotalBefore: number // 기존 점수
-
-    webElements: Solution[] // 개선 방안 ( 웹바이탈)
-    securityMetrics: Solution[] // 개선 방안 (보안)
-
-    majorImprovements: MajorImprovement[] // 기대효과 리스트
   }
 }


### PR DESCRIPTION
# feat : 기대효과 & 개선방안 페이지 API 연동 
 
<img width="1638" height="1110" alt="image" src="https://github.com/user-attachments/assets/2a7bf41b-3bd5-4ff6-aab4-74d80732b070" />

- 기대효과 & 개선방안 API 연동
- 타입 선언
- 상태 선언
- 기대효과 부분만 소프트 코딩으로 변경 
-
### 다음에 할 일
```javascript
        setBeforeScore(response.success.data.overallTotalBefore) // 기존 점수
        setAfterScore(response.success.data.overallTotalAfter) // 개선 예상 점수
        setAfterScoreDetail(response.success.data.overallExpectedImprovement) // 개선 예상 점수 디테일
        setSolutionWebVitalData(response.success.data.webElements) // 웹바이탈 개선방안
        setSolutionSecurityData(response.success.data.securityMetrics) // 보안 개선방안
        // TODO : 이 위에 5개 소프트하게 만들기
        setMajorImprovementData(response.success.data.majorImprovements) // 기대 효과
```
- 위 5개 API 받아온 데이터를 소프트하게 나타내기 