### PR TITLE
개선 방안 & 효과, 대시보드 페이지 수정 

### DIFF
--- a/src/components/Charts/SimplePieChart.tsx
+++ b/src/components/Charts/SimplePieChart.tsx
@@ -1,0 +1,66 @@
+import type { PieChartProps } from '@/types/Chart.types'
+import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts'
+
+/**
+ * 파이차트
+ * @param value : number - 차트 기준 값
+ * @param colors : string[2] - 기준 색상, 기본 색상 2개 넘겨줘야함.
+ * @returns
+ */
+const SimplePieChart: React.FC<PieChartProps> = ({
+  isValue = true,
+  value = 80,
+  colors = ['#e74c3c', '#f3f6f9'],
+  innerRadius = 50,
+  outerRadius = 60,
+}) => {
+  // 전체 데이터 구성: [진행된 값, 나머지 값]
+  const data = [
+    { name: 'Value', value: value },
+    { name: 'Remaining', value: 100 - value },
+  ]
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%" // 중심 X 좌표
+            cy="50%" // 중심 Y 좌표
+            innerRadius={innerRadius} // 도넛의 안쪽 반지름 (이 값으로 두께 조절)
+            outerRadius={outerRadius} // 도넛의 바깥쪽 반지름
+            startAngle={90} // 12시 방향에서 시작 (Recharts는 3시가 0도)
+            endAngle={-270} // 한 바퀴(360도) 돌리기
+            dataKey="value"
+            stroke="none" // 테두리 없애기
+            cornerRadius="50%" // 코너 둥글게
+          >
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+
+      {/* 중앙 텍스트 (CSS로 중앙 정렬) */}
+      {isValue && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            fontSize: '32px',
+            fontWeight: 'bold',
+            color: '#000',
+          }}
+        >
+          {value}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SimplePieChart

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -6,7 +6,6 @@ import img_sequrity from '@/assets/icons/sequrity.svg'
 
 import CustomBarChart from './CustomBarChart'
 import MetricSection from './Metric/MetricSection'
-import { performanceMetrics, securityMetrics } from './Metric/Metric.data'
 import { useEffect, useState } from 'react'
 import {
   fetchAiPriority,
@@ -23,8 +22,8 @@ export default function PerformanceDashboardMain() {
   const [testId, setTestId] = useState<string>('') // 테스트 ID
 
   const [priorityData, setPriorityData] = useState<AiPriority[] | null>(null) // 우선 개선이 필요한 항목 데이터
-  const [webVitalData, setWebVitalData] = useState<Vital[]>(performanceMetrics) // 우선 개선이 필요한 항목 데이터
-  const [securityVitalData, setSecurityVitalData] = useState<Vital[]>(securityMetrics) // 우선 개선이 필요한 항목 데이터
+  const [webVitalData, setWebVitalData] = useState<Vital[] | null>(null) // 우선 개선이 필요한 항목 데이터
+  const [securityVitalData, setSecurityVitalData] = useState<Vital[] | null>(null) // 우선 개선이 필요한 항목 데이터
 
   // 첫번째 차트 관련 블록
   const [urlAndDomainData, setUrlAndDomainData] = useState<DomainURL | null>(null) // 도메인, url
@@ -164,7 +163,7 @@ export default function PerformanceDashboardMain() {
                   // TODO : 추후에 데이터 넣어서 변경
                   <div className="border-box relative flex h-full w-full flex-col items-center justify-center rounded-[15px] p-2 shadow-md">
                     <div className="border-box absolute top-2 flex w-full flex-row items-center px-2">
-                      <div className="w-full text-[16px] text-[#83869A]">{item}</div>
+                      <div className="w-fㄴull text-[16px] text-[#83869A]">{item}</div>
                       <span className="inline-block h-[10px] w-[10px] rounded-full bg-[#FF3C3C]"></span>
                     </div>
                     <div className="text-[34px] font-semibold text-[#3B3D53]">45</div>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -16,11 +16,12 @@ import {
   fetchWebVitals,
 } from '@/apis/dashboardApis'
 import type { AiPriority, DomainURL, ScoreTotal, Vital } from '@/types/Dashboard.types'
+import type { CurTest } from '@/types/Test.types'
 
 export default function PerformanceDashboardMain() {
-  // TODO : 추후 테스트ID 동적으로  변경
-  const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
-  // 변수 ====
+  // ! 변수 ====
+  const [testId, setTestId] = useState<string>('') // 테스트 ID
+
   const [priorityData, setPriorityData] = useState<AiPriority[] | null>(null) // 우선 개선이 필요한 항목 데이터
   const [webVitalData, setWebVitalData] = useState<Vital[]>(performanceMetrics) // 우선 개선이 필요한 항목 데이터
   const [securityVitalData, setSecurityVitalData] = useState<Vital[]>(securityMetrics) // 우선 개선이 필요한 항목 데이터
@@ -31,7 +32,15 @@ export default function PerformanceDashboardMain() {
 
   // ======
 
-  // * 첫 렌더링 시 우선 개선사항 받아오기
+  //* 첫 렌더링시 테스트 ID 받아오기
+  useEffect(() => {
+    if (typeof chrome === 'undefined' || !chrome.storage?.local) return
+    chrome.storage.local.get<{ curTest?: CurTest }>('curTest', ({ curTest }) => {
+      if (curTest?.testId) setTestId(curTest.testId)
+    })
+  }, [])
+
+  // * testID 받아오면 우선 개선사항 받아오기
   useEffect(() => {
     // * 우선 개선사항 받아오기
     const getAiPriority = async () => {
@@ -86,13 +95,13 @@ export default function PerformanceDashboardMain() {
         console.error(error)
       }
     }
-    //
+
     getAiPriority()
     getWebVitals()
     getSecurityVitals()
     getURLandDomain()
     getScoreTotal()
-  }, [])
+  }, [testId])
 
   return (
     <main className="flex w-full max-w-[1700px] flex-col items-center justify-center gap-y-6 bg-[#F5F9FA] px-6 py-6 lg:px-8">

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/apis/dashboardApis'
 import type { AiPriority, DomainURL, ScoreTotal, Vital } from '@/types/Dashboard.types'
 import type { CurTest } from '@/types/Test.types'
+import SimplePieChart from '@/components/Charts/SimplePieChart'
 
 export default function PerformanceDashboardMain() {
   // ! 변수 ====
@@ -147,7 +148,17 @@ export default function PerformanceDashboardMain() {
           {/* 카드섹션  */}
           <section className="flex flex-1 flex-col items-center gap-y-2">
             <section className="box-border flex min-h-[92px] w-[261px] flex-row items-center justify-around gap-x-4 rounded-[15px] bg-[#FFFFFF] shadow-md">
-              <div className="h-16 w-16 rounded-full border-8 border-[#E3F2FD] border-t-[#3A7CA5]"></div>
+              {/* <div className="h-16 w-16 rounded-full border-8 border-[#E3F2FD] border-t-[#3A7CA5]"></div> */}
+              <div className="h-16 w-16">
+                <SimplePieChart
+                  value={scoreTotalData?.totalScore}
+                  colors={['#3A7CA5', '#EDEBF0']}
+                  innerRadius={20}
+                  outerRadius={30}
+                  isValue={false}
+                />
+              </div>
+
               <div className="flex flex-col justify-start gap-x-4">
                 <div className="text-[34px] font-semibold text-[#3B3D53]">
                   {scoreTotalData?.totalScore || '-'}점

--- a/src/pages/Dashboard/Metric/Metric.types.ts
+++ b/src/pages/Dashboard/Metric/Metric.types.ts
@@ -8,5 +8,5 @@ import type { Vital } from '@/types/Dashboard.types'
 export interface MetricsSectionProps {
   title: string
   titleIcon: string
-  metricDatas: Vital[]
+  metricDatas: Vital[] | null
 }

--- a/src/pages/SolutionPage/SolutionCards.tsx
+++ b/src/pages/SolutionPage/SolutionCards.tsx
@@ -1,13 +1,22 @@
+import { useState } from 'react'
 import type { Solution } from '@/types/Solution.types'
 import styles from './SolutionPage.module.scss'
 
-// ! 개선방안 카드
+// ! 개선방안 카드 나타내는 코드
 interface SolutionProps {
   data: Solution[] | null
 }
 
-export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
-  return data?.map((item) => (
+// * 1. 개별 아이템을 담당할 컴포넌트 분리
+const SolutionItem: React.FC<{ item: Solution }> = ({ item }) => {
+  // 2. 각 카드별로 열림/닫힘 상태 관리
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleDetail = () => {
+    setIsOpen((prev) => !prev)
+  }
+
+  return (
     <section className={styles.sub_container}>
       <div className={`${styles.state} ${styles[item.status]}`}>{item.status}</div>
       <h3 className={styles.sub_title}>{item.name}</h3>
@@ -21,20 +30,46 @@ export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
         <article className={styles.inner_item}>
           <h4>연관 지표</h4>
           <div className={styles.indicator_container}>
-            {item.relatedMetrics?.map((metric) => (
-              <div className={styles.item}>{metric}</div>
+            {item.relatedMetrics?.map((metric, index) => (
+              <div key={index} className={styles.item}>
+                {metric}
+              </div>
             ))}
           </div>
         </article>
       </section>
 
-      <section className={styles.detail_container}>
-        <h4>상세 개선 방안</h4>
-        <div className={styles.inner_item}>{item.benefitDetail}</div>
-      </section>
-      <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
+      {/* 3. isOpen 상태에 따라 상세 내용 조건부 렌더링 */}
+      {isOpen && (
+        <section className={styles.detail_container}>
+          <h4>상세 개선 방안</h4>
+          <div className={styles.inner_item}>{item.benefitDetail}</div>
+        </section>
+      )}
+
+      {/* 4. 클릭 시 상태 토글 및 텍스트/아이콘 변경 */}
+      <div
+        className={styles.btn_detail}
+        onClick={toggleDetail}
+        role="button"
+        style={{ cursor: 'pointer' }}
+      >
+        {isOpen ? '접기 >' : '자세히 보기 >'}
+      </div>
     </section>
-  ))
+  )
+}
+
+// *메인 컴포넌트
+export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
+  return (
+    <>
+      {data?.map((item, index) => (
+        // 각 아이템에 고유 key 부여 (name이 고유하다면 item.name 사용 권장)
+        <SolutionItem key={item.name || index} item={item} />
+      ))}
+    </>
+  )
 }
 
 export default SolutionCards

--- a/src/pages/SolutionPage/SolutionCards.tsx
+++ b/src/pages/SolutionPage/SolutionCards.tsx
@@ -1,0 +1,40 @@
+import type { Solution } from '@/types/Solution.types'
+import styles from './SolutionPage.module.scss'
+
+// ! 개선방안 카드
+interface SolutionProps {
+  data: Solution[] | null
+}
+
+export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
+  return data?.map((item) => (
+    <section className={styles.sub_container}>
+      <div className={`${styles.state} ${styles[item.status]}`}>{item.status}</div>
+      <h3 className={styles.sub_title}>{item.name}</h3>
+      <p className={styles.sub_summary}>{item.benefitSummary}</p>
+
+      <section className={styles.sub_effect_container}>
+        <article className={styles.inner_item}>
+          <h4>예상 개선 효과</h4>
+          <div className={styles.description}>성능 점수 +{item.expectedScoreGain}점</div>
+        </article>
+        <article className={styles.inner_item}>
+          <h4>연관 지표</h4>
+          <div className={styles.indicator_container}>
+            {item.relatedMetrics?.map((metric) => (
+              <div className={styles.item}>{metric}</div>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className={styles.detail_container}>
+        <h4>상세 개선 방안</h4>
+        <div className={styles.inner_item}>{item.benefitDetail}</div>
+      </section>
+      <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
+    </section>
+  ))
+}
+
+export default SolutionCards

--- a/src/pages/SolutionPage/SolutionPage.module.scss
+++ b/src/pages/SolutionPage/SolutionPage.module.scss
@@ -62,7 +62,7 @@
             @apply box-border flex w-full gap-x-2;
 
             .item {
-              @apply flex h-[27px] w-[72px] items-center justify-center rounded-[5px] bg-[#E8F4F7] text-[14px] font-semibold text-[#007BA7];
+              @apply flex h-[27px] min-w-[72px] items-center justify-center rounded-[5px] bg-[#E8F4F7] px-4 text-[14px] font-semibold text-[#007BA7];
             }
           }
         }

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -1,86 +1,12 @@
 import ArrowRight from '../../assets/icons/arrowRight.svg'
 import styles from './SolutionPage.module.scss'
-import Slider from 'react-slick'
-import 'slick-carousel/slick/slick.css'
-import 'slick-carousel/slick/slick-theme.css'
-import lightningImg from '../../assets/icons/lightning.svg'
+
 import { useEffect, useState } from 'react'
 import { fetchSolutions } from '@/apis/solutionApis'
 import type { MajorImprovement, Solution, SolutionResponse } from '@/types/Solution.types'
 import type { CurTest } from '@/types/Test.types'
-
-// Props 선언
-interface SolutionSliderProps {
-  data: MajorImprovement[] | null
-}
-
-// ! 개선방안 슬라이더
-const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
-  const settings = {
-    dots: true,
-    infinite: true,
-    speed: 500,
-    slidesToShow: 3,
-    slidesToScroll: 3,
-  }
-
-  return (
-    <div className="slider-container mx-[1%] h-[230px] w-full">
-      <Slider {...settings}>
-        {data?.map((item) => (
-          <article
-            key={item.description}
-            className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md"
-          >
-            <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
-              <img src={lightningImg} alt="번개" />
-            </div>
-            <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
-              <span className="text-[#3B82F6]">{item.metric}</span> {item.title}
-            </div>
-            <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">{item.description}</div>
-          </article>
-        ))}
-      </Slider>
-    </div>
-  )
-}
-
-// ! 개선방안 카드
-interface SolutionProps {
-  data: Solution[] | null
-}
-
-export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
-  return data?.map((item) => (
-    <section className={styles.sub_container}>
-      <div className={`${styles.state} ${styles[item.status]}`}>{item.status}</div>
-      <h3 className={styles.sub_title}>{item.name}</h3>
-      <p className={styles.sub_summary}>{item.benefitSummary}</p>
-
-      <section className={styles.sub_effect_container}>
-        <article className={styles.inner_item}>
-          <h4>예상 개선 효과</h4>
-          <div className={styles.description}>성능 점수 +{item.expectedScoreGain}점</div>
-        </article>
-        <article className={styles.inner_item}>
-          <h4>연관 지표</h4>
-          <div className={styles.indicator_container}>
-            {item.relatedMetrics?.map((metric) => (
-              <div className={styles.item}>{metric}</div>
-            ))}
-          </div>
-        </article>
-      </section>
-
-      <section className={styles.detail_container}>
-        <h4>상세 개선 방안</h4>
-        <div className={styles.inner_item}>{item.benefitDetail}</div>
-      </section>
-      <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
-    </section>
-  ))
-}
+import SolutionSlider from './SolutionSlider'
+import SolutionCards from './SolutionCards'
 
 export default function SolutionPage() {
   // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -7,13 +7,14 @@ import lightningImg from '../../assets/icons/lightning.svg'
 import { useEffect, useState } from 'react'
 import { fetchSolutions } from '@/apis/solutionApis'
 import type { MajorImprovement, Solution, SolutionResponse } from '@/types/Solution.types'
+import type { CurTest } from '@/types/Test.types'
 
 // Props 선언
 interface SolutionSliderProps {
   data: MajorImprovement[] | null
 }
 
-// * 개선방안 슬라이더
+// ! 개선방안 슬라이더
 const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
   const settings = {
     dots: true,
@@ -46,7 +47,9 @@ const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
 }
 
 export default function SolutionPage() {
-  const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
+  // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
+
+  const [testId, setTestId] = useState<string>('') // 테스트 ID
 
   // ! 변수 ===
   // 기존 점수
@@ -63,7 +66,7 @@ export default function SolutionPage() {
   // 기대 효과
   const [majorImprovementData, setMajorImprovementData] = useState<MajorImprovement[] | null>(null)
 
-  // * 첫 렌더링 시 API 호출
+  // * 테스트 ID 받아오면 API 호출
   useEffect(() => {
     // * 우선 개선사항 받아오기
     const getSolutions = async () => {
@@ -81,6 +84,14 @@ export default function SolutionPage() {
     }
 
     getSolutions()
+  }, [testId])
+
+  //* 첫 렌더링시 테스트 ID 받아오기
+  useEffect(() => {
+    if (typeof chrome === 'undefined' || !chrome.storage?.local) return
+    chrome.storage.local.get<{ curTest?: CurTest }>('curTest', ({ curTest }) => {
+      if (curTest?.testId) setTestId(curTest.testId)
+    })
   }, [])
 
   return (

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -46,10 +46,46 @@ const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
   )
 }
 
+// ! 개선방안 카드
+interface SolutionProps {
+  data: Solution[] | null
+}
+
+export const SolutionCards: React.FC<SolutionProps> = ({ data }) => {
+  return data?.map((item) => (
+    <section className={styles.sub_container}>
+      <div className={`${styles.state} ${styles[item.status]}`}>{item.status}</div>
+      <h3 className={styles.sub_title}>{item.name}</h3>
+      <p className={styles.sub_summary}>{item.benefitSummary}</p>
+
+      <section className={styles.sub_effect_container}>
+        <article className={styles.inner_item}>
+          <h4>예상 개선 효과</h4>
+          <div className={styles.description}>성능 점수 +{item.expectedScoreGain}점</div>
+        </article>
+        <article className={styles.inner_item}>
+          <h4>연관 지표</h4>
+          <div className={styles.indicator_container}>
+            {item.relatedMetrics?.map((metric) => (
+              <div className={styles.item}>{metric}</div>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className={styles.detail_container}>
+        <h4>상세 개선 방안</h4>
+        <div className={styles.inner_item}>{item.benefitDetail}</div>
+      </section>
+      <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
+    </section>
+  ))
+}
+
 export default function SolutionPage() {
   // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
 
-  const [testId, setTestId] = useState<string>('') // 테스트 ID
+  const [testId, setTestId] = useState<string>('ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8') // 테스트 ID
 
   // ! 변수 ===
   // 기존 점수
@@ -134,63 +170,8 @@ export default function SolutionPage() {
         {/* 단계별 개선 방안  */}
         <article className={styles.step_solution_container}>
           <h2 className={styles.title}>단계별 개선 방안</h2>
-          {solutionWebVitalData?.map((item) => (
-            <section className={styles.sub_container}>
-              <div className={`${styles.state} ${styles[item.status]}`}>{item.status}</div>
-              <h3 className={styles.sub_title}>{item.name}</h3>
-              <p className={styles.sub_summary}>{item.benefitSummary}</p>
-
-              <section className={styles.sub_effect_container}>
-                <article className={styles.inner_item}>
-                  <h4>예상 개선 효과</h4>
-                  <div className={styles.description}>성능 점수 +{item.expectedScoreGain}점</div>
-                </article>
-                <article className={styles.inner_item}>
-                  <h4>연관 지표</h4>
-                  <div className={styles.indicator_container}>
-                    {item.relatedMetrics?.map((metric) => (
-                      <div className={styles.item}>{metric}</div>
-                    ))}
-                  </div>
-                </article>
-              </section>
-
-              <section className={styles.detail_container}>
-                <h4>상세 개선 방안</h4>
-                <div className={styles.inner_item}>{item.benefitDetail}</div>
-              </section>
-              <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
-            </section>
-          ))}
-
-          {solutionSecurityData?.map((item) => (
-            <section className={styles.sub_container}>
-              <div className={styles.state}>{item.status}</div>
-              <h3 className={styles.sub_title}>{item.name}</h3>
-              <p className={styles.sub_summary}>{item.benefitSummary}</p>
-
-              <section className={styles.sub_effect_container}>
-                <article className={styles.inner_item}>
-                  <h4>예상 개선 효과</h4>
-                  <div className={styles.description}>성능 점수 +{item.expectedScoreGain}점</div>
-                </article>
-                <article className={styles.inner_item}>
-                  <h4>연관 지표</h4>
-                  <div className={styles.indicator_container}>
-                    {item.relatedMetrics?.map((metric) => (
-                      <div className={styles.item}>{metric}</div>
-                    ))}
-                  </div>
-                </article>
-              </section>
-
-              <section className={styles.detail_container}>
-                <h4>상세 개선 방안</h4>
-                <div className={styles.inner_item}>{item.benefitDetail}</div>
-              </section>
-              <div className={styles.btn_detail}>자세히 보기 {'>'}</div>
-            </section>
-          ))}
+          <SolutionCards data={solutionWebVitalData} />
+          <SolutionCards data={solutionSecurityData} />
         </article>
 
         {/* 개선 기대효과 */}

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -7,6 +7,7 @@ import type { MajorImprovement, Solution, SolutionResponse } from '@/types/Solut
 import type { CurTest } from '@/types/Test.types'
 import SolutionSlider from './SolutionSlider'
 import SolutionCards from './SolutionCards'
+import SimplePieChart from '@/components/Charts/SimplePieChart'
 
 export default function SolutionPage() {
   // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
@@ -75,20 +76,40 @@ export default function SolutionPage() {
           <section className="relative flex flex-col items-center gap-y-3">
             <h3 className="absolute -top-7 text-[14px] text-[#4B4B4B]">기존 점수</h3>
             {/* 도넛 */}
-            <div className="flex h-24 w-24 items-center justify-center rounded-full border-8 border-[#EDEBF0] border-t-[#FF3C3C]">
-              <div className="text-[30px] font-semibold text-[#000000]">{beforeScore}</div>
+            <div className="relative h-28 w-28">
+              <SimplePieChart
+                innerRadius={45}
+                outerRadius={55}
+                value={beforeScore}
+                colors={['#FF3C3C', '#EDEBF0']}
+              />
             </div>
+            {/* <div className="flex h-24 w-24 items-center justify-center rounded-full border-8 border-[#EDEBF0] border-t-[#FF3C3C]">
+              <div className="text-[30px] font-semibold text-[#000000]">{beforeScore}</div>
+            </div> */}
           </section>
           <img src={ArrowRight} alt="->" />
 
           <section className="relative flex flex-col items-center gap-y-3">
             <h3 className="absolute -top-7 text-[14px] text-[#4B4B4B]">개선 예상 점수</h3>
             {/* 도넛 */}
-            <div className="flex h-24 w-24 items-center justify-center rounded-full border-8 border-[#EDEBF0] border-t-[#3A7CA5]">
-              <div className="text-[30px] font-semibold text-[#000000]">{afterScore}</div>
+            <div className="relative h-28 w-28">
+              <SimplePieChart
+                innerRadius={45}
+                outerRadius={55}
+                value={afterScore}
+                colors={['#3A7CA5', '#EDEBF0']}
+              />
             </div>
+            {/* <div className="flex h-24 w-24 items-center justify-center rounded-full border-8 border-[#EDEBF0] border-t-[#3A7CA5]">
+              <div className="text-[30px] font-semibold text-[#000000]">{afterScore}</div>
+            </div> */}
             <span className="absolute -bottom-8 text-[16px] font-semibold text-[#3A7CA5]">
-              {afterScoreDetail}점 +
+              {afterScoreDetail}점
+            </span>
+            <span className="absolute -bottom-8 right-7 text-[16px] font-semibold text-[#3A7CA5]">
+              {' '}
+              +
             </span>
           </section>
         </article>

--- a/src/pages/SolutionPage/SolutionSlider.tsx
+++ b/src/pages/SolutionPage/SolutionSlider.tsx
@@ -1,0 +1,44 @@
+import type { MajorImprovement } from '@/types/Solution.types'
+import Slider from 'react-slick'
+import lightningImg from '../../assets/icons/lightning.svg'
+import 'slick-carousel/slick/slick.css'
+import 'slick-carousel/slick/slick-theme.css'
+
+// Props 선언
+interface SolutionSliderProps {
+  data: MajorImprovement[] | null
+}
+
+// ! 개선방안->  기대효과 슬라이더
+const SolutionSlider: React.FC<SolutionSliderProps> = ({ data }) => {
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 3,
+    slidesToScroll: 3,
+  }
+
+  return (
+    <div className="slider-container mx-[1%] h-[230px] w-full">
+      <Slider {...settings}>
+        {data?.map((item) => (
+          <article
+            key={item.description}
+            className="box-border flex h-[225px] max-w-[95%] flex-1 flex-col rounded-[15px] bg-white p-10 shadow-md"
+          >
+            <div className="box-border flex h-[33px] w-[33px] items-center justify-center rounded-full bg-[#3B82F6]">
+              <img src={lightningImg} alt="번개" />
+            </div>
+            <div className="mt-2 pl-3 text-[21px] font-bold text-[#4B4B4B]">
+              <span className="text-[#3B82F6]">{item.metric}</span> {item.title}
+            </div>
+            <div className="mt-2 pl-3 text-[21px] font-bold text-[#707071]">{item.description}</div>
+          </article>
+        ))}
+      </Slider>
+    </div>
+  )
+}
+
+export default SolutionSlider

--- a/src/types/Chart.types.ts
+++ b/src/types/Chart.types.ts
@@ -45,3 +45,12 @@ export interface ChartsProps extends ChartProps {
 export interface MChartsProps extends MChartProps {
   chartType: 'mLine' | 'mLineArea'
 }
+
+// * 파이차트
+export interface PieChartProps {
+  isValue?: boolean // true / false로 text넣을건지
+  value?: number // 목표값
+  colors?: string[] // 색상 2개 (['#e74c3c', '#f3f6f9'])
+  innerRadius?: number // 내부
+  outerRadius?: number // 외부
+}


### PR DESCRIPTION
# 개선 방안 & 효과, 대시보드 페이지 수정 

<img width="1683" height="1332" alt="image" src="https://github.com/user-attachments/assets/226339ad-86af-435b-89ab-b16188964465" />


### 변경 사항 
- 기존 점수, 개선 예상 점수, 토탈 점수를 파이 그래프로 변경하고, 원 내부 값에 따라 채워지게 변경
- 파이 그래프 컴포넌트 추가 
- 세부 개선방안들 자세히 보기 및 접기 기능 추가
- 크롬 확장 프로그램에서 testid 받아오도록 변경
- solution 페이지 리펙토링 (컴포넌트화)
  - 예를 들어서  세부 개선방안 부분 카드로 나누는 등 리팩토링 
- soution 브랜치에서 dashboard도 고쳤습니다 죄송해유..
- 개선 예상 점수 밑  + 돼있는 점수들 UI 가운대로 오게 수정 
- 
### 남은 할일 
- 대시보드 화면 일부 API 연동 