### PR TITLE
fix : 대시보드 차트, 지표 점수 api 재연동, 우선 개선필요항목 색상 상태에따라 동적 변경 수정

### DIFF
--- a/src/apis/dashboardApis.ts
+++ b/src/apis/dashboardApis.ts
@@ -1,6 +1,7 @@
 import type {
   AiPriorityResponse,
   DomainURLResponse,
+  ScoreResponse,
   ScoreTotalResponse,
   SecurityVitalsResponse,
   WebVitalItemResponse,
@@ -52,6 +53,18 @@ export const fetchSecurityVitals = async (testId: string): Promise<SecurityVital
 export const fetchScoreTotal = async (testId: string): Promise<ScoreTotalResponse> => {
   try {
     const url = `/api/tests/${testId}/scores/total`
+    const response = await defaultAxios.get(url)
+    return response.data
+  } catch (error) {
+    console.error('Failed to fetch cell sum data', error)
+    throw error
+  }
+}
+
+// * 대시보드 6개 점수, 차트 점수
+export const fetchScores = async (testId: string): Promise<ScoreResponse> => {
+  try {
+    const url = `/api/tests/${testId}/scores`
     const response = await defaultAxios.get(url)
     return response.data
   } catch (error) {

--- a/src/apis/dashboardApis.ts
+++ b/src/apis/dashboardApis.ts
@@ -68,7 +68,7 @@ export const fetchScores = async (testId: string): Promise<ScoreResponse> => {
     const response = await defaultAxios.get(url)
     return response.data
   } catch (error) {
-    console.error('Failed to fetch cell sum data', error)
+    console.error('Failed to fetch scores data', error)
     throw error
   }
 }

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import img_error from '@/assets/icons/error.svg'
-// import img_ok from '@/assets/icons/ok.svg'
-// import img_warning from '@/assets/icons/warning.svg'
+import img_ok from '@/assets/icons/ok.svg'
+import img_warning from '@/assets/icons/warning.svg'
 import img_fire from '@/assets/icons/fire.svg'
 import img_sequrity from '@/assets/icons/sequrity.svg'
 
@@ -9,18 +9,25 @@ import MetricSection from './Metric/MetricSection'
 import { useEffect, useState } from 'react'
 import {
   fetchAiPriority,
+  fetchScores,
   fetchScoreTotal,
   fetchSecurityVitals,
   fetchURLandDomain,
   fetchWebVitals,
 } from '@/apis/dashboardApis'
-import type { AiPriority, DomainURL, ScoreTotal, Vital } from '@/types/Dashboard.types'
+import {
+  type Score,
+  type AiPriority,
+  type DomainURL,
+  type ScoreTotal,
+  type Vital,
+} from '@/types/Dashboard.types'
 import type { CurTest } from '@/types/Test.types'
 import SimplePieChart from '@/components/Charts/SimplePieChart'
 
 export default function PerformanceDashboardMain() {
   // ! 변수 ====
-  const [testId, setTestId] = useState<string>('') // 테스트 ID
+  const [testId, setTestId] = useState<string>('1ca4c78e-649d-47d9-85a4-6df51918bb7d') // 테스트 ID
 
   const [priorityData, setPriorityData] = useState<AiPriority[] | null>(null) // 우선 개선이 필요한 항목 데이터
   const [webVitalData, setWebVitalData] = useState<Vital[] | null>(null) // 우선 개선이 필요한 항목 데이터
@@ -29,7 +36,7 @@ export default function PerformanceDashboardMain() {
   // 첫번째 차트 관련 블록
   const [urlAndDomainData, setUrlAndDomainData] = useState<DomainURL | null>(null) // 도메인, url
   const [scoreTotalData, setScoreTotalData] = useState<ScoreTotal | null>(null) // 도메인, url
-
+  const [scoreData, setScoreData] = useState<Score[] | null>(null) // 차트데이터
   // ======
 
   //* 첫 렌더링시 테스트 ID 받아오기
@@ -96,11 +103,23 @@ export default function PerformanceDashboardMain() {
       }
     }
 
+    //* 대시보드 total 점수 받아오기
+    const getScores = async () => {
+      try {
+        const response = await fetchScores(testId) // 대시보드/우선개선이 필요한 항목
+        setScoreData(response?.success?.data?.charData)
+        console.log('setScoresData', response)
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
     getAiPriority()
     getWebVitals()
     getSecurityVitals()
     getURLandDomain()
     getScoreTotal()
+    getScores()
   }, [testId])
 
   return (
@@ -109,7 +128,7 @@ export default function PerformanceDashboardMain() {
       <article className="// TODO : max-w 추후 삭제 (비율 맞추기 ) relative box-border flex h-[394px] w-full max-w-[953px] flex-col rounded-[15px] border-2 border-solid border-[#DEEBEF] bg-[#FFFFFF] p-4 shadow-md">
         <header>
           {/* 아이템  */}
-          <div className="absolute -top-7 left-4 flex flex-row justify-start gap-x-4 text-[14px] text-sm font-semibold text-[#5C5C5C] text-gray-500">
+          <div className="absolute -top-7 left-4 flex flex-row justify-start gap-x-4 text-[14px] text-sm font-semibold text-[#5C5C5C]">
             <div className="flex flex-row items-center justify-start">
               <span className="mr-1 inline-block h-[7px] w-[7px] rounded-full bg-[#357BFA]"></span>
               <span>GOOD</span>
@@ -143,7 +162,13 @@ export default function PerformanceDashboardMain() {
         <section className="flex h-full w-full flex-row justify-start gap-x-4">
           {/* 차트 섹션 */}
           <section className="max-h-[284px] max-w-[452px] flex-1">
-            <CustomBarChart title="" yLabel="" />
+            <CustomBarChart
+              title=""
+              yLabel=""
+              data={scoreData ?? undefined}
+              dataKey="score"
+              name="name"
+            />
           </section>
           {/* 카드섹션  */}
           <section className="flex flex-1 flex-col items-center gap-y-2">
@@ -167,17 +192,28 @@ export default function PerformanceDashboardMain() {
               </div>
             </section>
             {/* 그리드 컴포넌트 2*3 */}
-            <section className="grid h-full w-full grid-cols-3 grid-rows-2 gap-3 gap-4">
+            <section className="grid h-full w-full grid-cols-3 grid-rows-2 gap-4">
               {/* 카드 6개 */}
-              {['LCP', 'CLS', 'INP', 'FCP', 'TTFB', 'sequrity'].map((item) => {
+              {scoreData?.map((item) => {
                 return (
                   // TODO : 추후에 데이터 넣어서 변경
                   <div className="border-box relative flex h-full w-full flex-col items-center justify-center rounded-[15px] p-2 shadow-md">
                     <div className="border-box absolute top-2 flex w-full flex-row items-center px-2">
-                      <div className="w-fㄴull text-[16px] text-[#83869A]">{item}</div>
-                      <span className="inline-block h-[10px] w-[10px] rounded-full bg-[#FF3C3C]"></span>
+                      <div className="w-full text-[16px] text-[#83869A]">{item.name}</div>
+                      {/* border-[#FABF35]  border-[#357BFA] */}
+                      {item.urgentStatus && ( // 값에 따라 색상 다르게 하기
+                        <span
+                          className={`inline-block h-[10px] w-[10px] rounded-full ${
+                            item.urgentStatus === 'GOOD'
+                              ? 'bg-[#357BFA]'
+                              : item.urgentStatus === 'WARNING'
+                                ? 'bg-[#FABF35]'
+                                : 'bg-[#FF3C3C]'
+                          } `}
+                        ></span>
+                      )}
                     </div>
-                    <div className="text-[34px] font-semibold text-[#3B3D53]">45</div>
+                    <div className="text-[34px] font-semibold text-[#3B3D53]">{item.score}</div>
                   </div>
                 )
               })}
@@ -188,9 +224,7 @@ export default function PerformanceDashboardMain() {
 
       {/* 우선 개선이 필요한 항목 */}
       <article className="// TODO : max-width 추후 삭제, 크기 맞춰야 relative box-border flex w-full max-w-[953px] flex-col gap-y-5 rounded-[15px] border-2 border-solid border-[#DEEBEF] bg-[#FFFFFF] p-4 shadow-md">
-        <h2 className="text-[12px] text-[20px] font-semibold text-[#4B4B4B]">
-          🚨 우선 개선이 필요한 항목
-        </h2>
+        <h2 className="text-[20px] font-semibold text-[#4B4B4B]">🚨 우선 개선이 필요한 항목</h2>
         {/* 
           // TODO : img, 상태에 따라 색상에 바뀌게 만들 것이다. (추후 수정된 데이터 받으면)
         */}
@@ -198,8 +232,20 @@ export default function PerformanceDashboardMain() {
         {// border-[#FABF35]  border-[#357BFA]
         priorityData?.map((item) => (
           <ul className="flex flex-col gap-y-4">
-            <li className="box-border flex h-[58px] w-full flex-row items-center justify-center gap-x-4 rounded-[10px] border-l-4 border-[#FF3C3C] bg-[#F8F9FA] px-4">
-              <img src={img_error} />
+            <li
+              className={`box-border flex h-[58px] w-full flex-row items-center justify-center gap-x-4 rounded-[10px] border-l-4 ${
+                item.status === '양호'
+                  ? 'border-[#357BFA]'
+                  : item.status === '주의'
+                    ? 'border-[#FABF35]'
+                    : 'border-[#FF3C3C]' // 긴급
+              } bg-[#F8F9FA] px-4`}
+            >
+              <img
+                src={
+                  item.status === '양호' ? img_ok : item.status === '주의' ? img_warning : img_error
+                }
+              />
               <div className="box-border flex h-full w-full flex-col justify-center">
                 <div className="text-[16px] font-semibold text-[#4B4B4B]">{item.targetName}</div>
                 <div className="text-[12px] font-semibold text-[#888888]">{item.reason}</div>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -27,7 +27,7 @@ import SimplePieChart from '@/components/Charts/SimplePieChart'
 
 export default function PerformanceDashboardMain() {
   // ! 변수 ====
-  const [testId, setTestId] = useState<string>('1ca4c78e-649d-47d9-85a4-6df51918bb7d') // 테스트 ID
+  const [testId, setTestId] = useState<string>('') // 테스트 ID
 
   const [priorityData, setPriorityData] = useState<AiPriority[] | null>(null) // 우선 개선이 필요한 항목 데이터
   const [webVitalData, setWebVitalData] = useState<Vital[] | null>(null) // 우선 개선이 필요한 항목 데이터
@@ -114,12 +114,15 @@ export default function PerformanceDashboardMain() {
       }
     }
 
-    getAiPriority()
-    getWebVitals()
-    getSecurityVitals()
-    getURLandDomain()
-    getScoreTotal()
-    getScores()
+    // 병렬로 API 호출 처리
+    Promise.all([
+      getAiPriority(),
+      getWebVitals(),
+      getSecurityVitals(),
+      getURLandDomain(),
+      getScoreTotal(),
+      getScores(),
+    ])
   }, [testId])
 
   return (
@@ -204,11 +207,11 @@ export default function PerformanceDashboardMain() {
                       {item.urgentStatus && ( // 값에 따라 색상 다르게 하기
                         <span
                           className={`inline-block h-[10px] w-[10px] rounded-full ${
-                            item.urgentStatus === 'GOOD'
-                              ? 'bg-[#357BFA]'
-                              : item.urgentStatus === 'WARNING'
-                                ? 'bg-[#FABF35]'
-                                : 'bg-[#FF3C3C]'
+                            {
+                              GOOD: 'bg-[#357BFA]',
+                              WARNING: 'bg-[#FABF35]',
+                              POOR: 'bg-[#FF3C3C]',
+                            }[item.urgentStatus]
                           } `}
                         ></span>
                       )}
@@ -234,16 +237,20 @@ export default function PerformanceDashboardMain() {
           <ul className="flex flex-col gap-y-4">
             <li
               className={`box-border flex h-[58px] w-full flex-row items-center justify-center gap-x-4 rounded-[10px] border-l-4 ${
-                item.status === '양호'
-                  ? 'border-[#357BFA]'
-                  : item.status === '주의'
-                    ? 'border-[#FABF35]'
-                    : 'border-[#FF3C3C]' // 긴급
+                {
+                  양호: 'border-[#357BFA]',
+                  주의: 'border-[#FABF35]',
+                  긴급: 'border-[#FF3C3C]',
+                }[item.status]
               } bg-[#F8F9FA] px-4`}
             >
               <img
                 src={
-                  item.status === '양호' ? img_ok : item.status === '주의' ? img_warning : img_error
+                  {
+                    양호: img_ok,
+                    주의: img_warning,
+                    긴급: img_error,
+                  }[item.status]
                 }
               />
               <div className="box-border flex h-full w-full flex-col justify-center">

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -12,7 +12,7 @@ import SimplePieChart from '@/components/Charts/SimplePieChart'
 export default function SolutionPage() {
   // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
 
-  const [testId, setTestId] = useState<string>('ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8') // 테스트 ID
+  const [testId, setTestId] = useState<string>('1ca4c78e-649d-47d9-85a4-6df51918bb7d') // 테스트 ID
 
   // ! 변수 ===
   // 기존 점수

--- a/src/pages/SolutionPage/SolutionPage.tsx
+++ b/src/pages/SolutionPage/SolutionPage.tsx
@@ -12,7 +12,7 @@ import SimplePieChart from '@/components/Charts/SimplePieChart'
 export default function SolutionPage() {
   // const testId: string = 'ab8f4ba8-bfa7-4b6a-bf05-7efc7b9723b8'
 
-  const [testId, setTestId] = useState<string>('1ca4c78e-649d-47d9-85a4-6df51918bb7d') // 테스트 ID
+  const [testId, setTestId] = useState<string>('') // 테스트 ID
 
   // ! 변수 ===
   // 기존 점수

--- a/src/types/Dashboard.types.ts
+++ b/src/types/Dashboard.types.ts
@@ -65,13 +65,32 @@ export interface ScoreTotalResponse {
 }
 
 // =================================
+// * (세부점수 조회) 차트 데이터 score 받아오기
+
+export interface Score {
+  name: string // lcp
+  score: number // 100
+  urgentStatus?: 'GOOD' | 'WARNING' | 'POOR' | null | undefined
+}
+
+export interface ScoreResponse {
+  success: {
+    message: string
+    total: number // 총점
+    data: {
+      charData: Score[]
+    }
+    createdAt: string
+  }
+}
+// =================================
 
 // * 대시보드/우선 개선이 필요한 항목
 export interface AiPriority {
   rank: number
   targetType: string
   targetName: string
-  expectedGain: number
+  status: '긴급' | '주의' | '양호'
   reason: string
 }
 // * 총 3개가 나온다.


### PR DESCRIPTION
# fix : 대시보드 차트, 지표 점수 api 재연동, 우선 개선필요항목 색상 상태에따라 동적 변경 수정

<img width="1270" height="517" alt="image" src="https://github.com/user-attachments/assets/617edcd0-4558-4d89-819d-fbb3b5b9bc8b" />
<img width="1116" height="357" alt="image" src="https://github.com/user-attachments/assets/2d20bb66-a2d9-47df-83b8-de86446c3f9e" />

### 진행 상황
- /scores API 제대로 연동해서 대시보드 차트, 지표 점수 연동 완료
- 지표 점수중에 마지막 보안 부분은 백엔드측에서 넣어주면 자동으로 생김
- 우선선개선이 필요한 항목 부분 상태에 따라 '양호, 주의, 경고??' 색상이 변경됨 
- 소소한 css 중복 warning 제거 