### PR TITLE
fix: 자세히보기 이동 시 스크롤 오프셋 적용

### DIFF
--- a/src/components/Charts/SimplePieChart.tsx
+++ b/src/components/Charts/SimplePieChart.tsx
@@ -36,7 +36,7 @@ const SimplePieChart: React.FC<PieChartProps> = ({
             stroke="none" // 테두리 없애기
             cornerRadius="50%" // 코너 둥글게
           >
-            {data.map((entry, index) => (
+            {data.map((_, index) => (
               <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
             ))}
           </Pie>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -26,6 +26,9 @@ import {
 import type { CurTest } from '@/types/Test.types'
 import SimplePieChart from '@/components/Charts/SimplePieChart'
 
+// "자세히 보기"에서 들어올 때 상단 여백을 가릴 정도로만 내려주는 오프셋
+const SCROLL_OFFSET = 120
+
 export default function PerformanceDashboardMain() {
   // ! 변수 ====
   const [testId, setTestId] = useState<string>('') // 테스트 ID
@@ -136,7 +139,7 @@ export default function PerformanceDashboardMain() {
 
     // 약간 아래로 스크롤 (헤더/여백 가리기용)
     window.requestAnimationFrame(() => {
-      window.scrollTo({ top: 120, behavior: 'smooth' })
+      window.scrollTo({ top: SCROLL_OFFSET, behavior: 'smooth' })
     })
 
     // 파라미터 제거하여 새로고침 시 반복되지 않게 함

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -27,7 +27,7 @@ import type { CurTest } from '@/types/Test.types'
 import SimplePieChart from '@/components/Charts/SimplePieChart'
 
 // "자세히 보기"에서 들어올 때 상단 여백을 가릴 정도로만 내려주는 오프셋
-const SCROLL_OFFSET = 120
+const SCROLL_OFFSET = 100
 
 export default function PerformanceDashboardMain() {
   // ! 변수 ====

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import img_sequrity from '@/assets/icons/sequrity.svg'
 import CustomBarChart from './CustomBarChart'
 import MetricSection from './Metric/MetricSection'
 import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import {
   fetchAiPriority,
   fetchScores,
@@ -38,6 +39,8 @@ export default function PerformanceDashboardMain() {
   const [scoreTotalData, setScoreTotalData] = useState<ScoreTotal | null>(null) // 도메인, url
   const [scoreData, setScoreData] = useState<Score[] | null>(null) // 차트데이터
   // ======
+  const location = useLocation()
+  const navigate = useNavigate()
 
   //* 첫 렌더링시 테스트 ID 받아오기
   useEffect(() => {
@@ -124,6 +127,28 @@ export default function PerformanceDashboardMain() {
       getScores(),
     ])
   }, [testId])
+
+  // 팝업 "자세히 보기"에서 넘어올 때 약간 아래 위치에서 시작하도록 처리
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const shouldScroll = params.get('scroll') === 'detail'
+    if (!shouldScroll) return
+
+    // 약간 아래로 스크롤 (헤더/여백 가리기용)
+    window.requestAnimationFrame(() => {
+      window.scrollTo({ top: 120, behavior: 'smooth' })
+    })
+
+    // 파라미터 제거하여 새로고침 시 반복되지 않게 함
+    params.delete('scroll')
+    navigate(
+      {
+        pathname: location.pathname,
+        search: params.toString() ? `?${params.toString()}` : '',
+      },
+      { replace: true },
+    )
+  }, [location.pathname, location.search, navigate])
 
   return (
     <main className="flex w-full max-w-[1700px] flex-col items-center justify-center gap-y-6 bg-[#F5F9FA] px-6 py-6 lg:px-8">

--- a/src/pages/Popup.tsx
+++ b/src/pages/Popup.tsx
@@ -133,7 +133,8 @@ export default function Popup() {
 
   const openDetail = () => {
     const baseUrl = chrome.runtime.getURL('index.html')
-    const targetUrl = `${baseUrl}#/app/dashboard`
+    // 대시보드 진입 시 약간 아래로 스크롤하기 위한 힌트 파라미터
+    const targetUrl = `${baseUrl}#/app/dashboard?scroll=detail`
 
     chrome.tabs.query({}, (tabs) => {
       const existing = tabs.find((tab) => tab.url?.startsWith(`${baseUrl}#/app`))

--- a/src/types/ReactSlick.d.ts
+++ b/src/types/ReactSlick.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-slick'

--- a/src/types/react-slick.d.ts
+++ b/src/types/react-slick.d.ts
@@ -1,8 +1,0 @@
-import type { ComponentType } from 'react'
-
-declare module 'react-slick' {
-  // 최소 타입 스텁: 광범위한 props 허용, any 회피
-  type SliderProps = Record<string, unknown>
-  const Slider: ComponentType<SliderProps>
-  export default Slider
-}


### PR DESCRIPTION
 팝업에서 “자세히 보기” 누르면 대시보드가 살짝 아래로 내려간 상태에서 열리게함팝업에서 “자세히 보기” 누르면 대시보드가 살짝 아래로 내려간 상태에서 열리게함
 
<img width="1385" height="872" alt="image" src="https://github.com/user-attachments/assets/8d24d917-4ce8-445e-bc58-e03c07a477ae" />

 
 react-slick 타입 오류 안 나도록 이름 맞춘 선언 파일만 하나 추가
 빌드 깨지던 경고 하나 없애려고 파이차트에서 안 쓰는 변수 처리