### PR TITLE
fix : 대시보드 차트 API 응답 데이터로 연동

### DIFF
--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -120,7 +120,7 @@ export default function PerformanceDashboardMain() {
       }
     }
 
-    //* 대시보드 total 점수 받아오기
+    //* 대시보드 점수 받아오기
     const getScores = async () => {
       try {
         const response = await fetchScores(testId) // 대시보드/우선개선이 필요한 항목
@@ -208,7 +208,7 @@ export default function PerformanceDashboardMain() {
               title=""
               yLabel=""
               // data={scoreData ?? undefined}
-              data={testData}
+              data={scoreData ?? testData}
               dataKey="score"
               name="name"
             />
@@ -239,7 +239,6 @@ export default function PerformanceDashboardMain() {
               {/* 카드 6개 */}
               {scoreData?.map((item) => {
                 return (
-                  // TODO : 추후에 데이터 넣어서 변경
                   <div className="border-box relative flex h-full w-full flex-col items-center justify-center rounded-[15px] p-2 shadow-md">
                     <div className="border-box absolute top-2 flex w-full flex-row items-center px-2">
                       <div className="w-full text-[16px] text-[#83869A]">{item.name}</div>


### PR DESCRIPTION
## fix : 대시보드 차트 API 응답 데이터로 연동

### 수정 사항
- 대시보드 페이지 바 차트 API 응답 데이터로 연결 
<img width="718" height="331" alt="image" src="https://github.com/user-attachments/assets/9fe28a22-114e-41b2-af2a-0011d82e0072" />

- 오른쪽 점수와 왼쪽 차트 데이터가 잘 매핑되는 것을 확인할 수 있습니다.
